### PR TITLE
Added Vale linter bot

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,11 @@
+StylesPath = styles
+
+MinAlertLevel = suggestion
+Vocab = Base
+
+
+[*]
+BasedOnStyles = Vale, RTD
+
+Vale.Spelling = YES
+Vale.Repetition = YES

--- a/styles/RTD/Naming.yml
+++ b/styles/RTD/Naming.yml
@@ -1,0 +1,6 @@
+extends: substitution
+message: Use '%s' instead of '%s'
+level: error
+swap:
+  RTD: Read the Docs
+  Read The Docs: Read the Docs

--- a/styles/Vocab/Base/accept.txt
+++ b/styles/Vocab/Base/accept.txt
@@ -1,0 +1,2 @@
+MKDocs
+Conda


### PR DESCRIPTION
Added Vale linter bot to search for and replaces incorrect spellings of Read the Docs including RTD and Read The Docs. Linter bot also checks for spelling errors and repetitions

Co-Authored-By: Melody  <75503741+melodyncr@users.noreply.github.com>
Co-Authored-By: ppansare <75503669+ppansare@users.noreply.github.com>

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--1.org.readthedocs.build/en/1/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--1.org.readthedocs.build/en/1/

<!-- readthedocs-preview dev end -->